### PR TITLE
fix for laft over Russian text

### DIFF
--- a/ext/cfx-ui/src/assets/languages/locale-en.json
+++ b/ext/cfx-ui/src/assets/languages/locale-en.json
@@ -19,7 +19,7 @@
     "#Servers_Connecting": "Connecting",
     "#Servers_ConnectingTo": "Connecting to {{ serverName }}...",
     "#Servers_ConnectFailed": "Connection failed",
-    "#Servers_Error": "Ошибка (Error)",
+    "#Servers_Error": "Mistake (Error)",
     "#Servers_Info": "Info",
     "#Servers_CloseOverlay": "Close",
     "#Servers_CancelOverlay": "Cancel",


### PR DESCRIPTION
please merge this simple update as its strange to see Russian on an en client